### PR TITLE
Docker: Support custom host-machine webserver ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v3.8.0] - 2021-06-25
+
+### Added
+- Docker: Add environment variables `DEV_WEBSERVER_PORT` and `NGINX_PORT` to configure which ports to use on host machine for webserver
+
+### Removed
+- Docker: Unexpose Redis port `6379` on host machine
+
+
 ## [v3.7.0] - 2021-06-21
 
 ### Added
@@ -211,7 +220,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Undocumented
 
 
-[Unreleased]: https://github.com/JeffreyCA/spleeter-web/compare/v3.7.0...HEAD
+[Unreleased]: https://github.com/JeffreyCA/spleeter-web/compare/v3.8.0...HEAD
+[v3.8.0]: https://github.com/JeffreyCA/spleeter-web/compare/v3.7.0...v3.8.0
 [v3.7.0]: https://github.com/JeffreyCA/spleeter-web/compare/v3.6.1...v3.7.0
 [v3.6.1]: https://github.com/JeffreyCA/spleeter-web/compare/v3.6.0...v3.6.1
 [v3.6.0]: https://github.com/JeffreyCA/spleeter-web/compare/v3.5.2...v3.6.0

--- a/README.md
+++ b/README.md
@@ -218,8 +218,10 @@ Here is a list of all the environment variables you can use to further customize
 | `AZURE_CUSTOM_DOMAIN` | Custom domain, such as for a CDN. Used when `DEFAULT_FILE_STORAGE` in `settings*.py` is set to `api.storage.AzureStorage`.|
 | `CELERY_BROKER_URL` | Broker URL for Celery (e.g. `redis://localhost:6379/0`). |
 | `CELERY_RESULT_BACKEND` | Result backend for Celery (e.g. `redis://localhost:6379/0`). |
-| `CELERY_FAST_QUEUE_CONCURRENCY` | Number of concurrent YouTube import tasks Celery can process (used only if run using Docker). |
-| `CELERY_SLOW_QUEUE_CONCURRENCY` | Number of concurrent source separation tasks Celery can process (used only if run using Docker).|
+| `CELERY_FAST_QUEUE_CONCURRENCY` | Number of concurrent YouTube import tasks Celery can process. Docker only. |
+| `CELERY_SLOW_QUEUE_CONCURRENCY` | Number of concurrent source separation tasks Celery can process. Docker only. |
+| `DEV_WEBSERVER_PORT` | Port that development webserver is mapped to on **host** machine. Docker only. |
+| `NGINX_PORT` | Port that Nginx is mapped to on **host** machine. Docker only. |
 | `YOUTUBE_API_KEY` | YouTube Data API key. |
 
 ## Using cloud storage (Azure Storage, AWS S3, etc.)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,9 +5,10 @@ services:
     restart: "no"
   api:
     ports:
-      - "8000:8000"
+      - "${DEV_WEBSERVER_PORT:-8000}:8000"
     environment:
       - DJANGO_DEVELOPMENT=true
+      - DEV_WEBSERVER_PORT
     volumes:
       - ./api:/webapp/api
       - ./media:/webapp/media

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,6 @@ services:
       - "${DEV_WEBSERVER_PORT:-8000}:8000"
     environment:
       - DJANGO_DEVELOPMENT=true
-      - DEV_WEBSERVER_PORT
     volumes:
       - ./api:/webapp/api
       - ./media:/webapp/media

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -20,8 +20,8 @@ services:
   redis:
     image: redis:6.0-buster
     hostname: redis
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
     volumes:
       - redis-data:/data
     restart: always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,9 @@ version: '3.4'
 services:
   nginx:
     ports:
-      - "80:80"
+      - "${NGINX_PORT:-80}:80"
+    environment:
+      - NGINX_PORT
   api:
     expose:
       - "8000"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,8 +3,6 @@ services:
   nginx:
     ports:
       - "${NGINX_PORT:-80}:80"
-    environment:
-      - NGINX_PORT
   api:
     expose:
       - "8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
   redis:
     image: redis:6.0-buster
     hostname: redis
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
     volumes:
       - redis-data:/data
     restart: always


### PR DESCRIPTION
Closes #85 

- Adds `DEV_WEBSERVER_PORT` and `NGINX_PORT` environment variables to support overriding the default host ports that the webserver runs on
- Unexpose Redis port