### PR TITLE
hotfix: don't break with auth

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -18,6 +18,7 @@ server {
         proxy_pass http://django_react;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
+        proxy_set_header Authorization "";
         proxy_redirect off;
     }
 }


### PR DESCRIPTION
Closes #124

Though, it'd be right to fix the actual issue (of django trying handle any auth at all).