### PR TITLE
Pin httpx dependency so spleeter follows redirects for model downloading

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
       - dependency-name: "librosa"            # Spleeter dependencies
       - dependency-name: "numba"              # Spleeter dependencies
       - dependency-name: "llvmlite"           # Spleeter dependencies
+      - dependency-name: "httpx"              # due to https://github.com/deezer/spleeter/pull/808
 
   - package-ecosystem: "npm"
     directory: "/frontend"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,8 @@ python-magic==0.4.27; sys_platform == 'linux'
 python-magic-bin==0.4.14; sys_platform != 'linux'
 # Spleeter dependencies
 ffmpeg-python==0.2.0
-httpx==0.26.0
+# Do NOT upgrade to 0.20.0 or later until https://github.com/deezer/spleeter/pull/808 is fixed
+httpx==0.19.0
 librosa==0.8.1
 # Override Spleeter's hard llvmlite dependency
 llvmlite==0.39.0


### PR DESCRIPTION
At the moment, `spleeter` model downloads are failing, at least for me, because:
* `spleeter` models when downloaded from github go through a redirection.
* `spleeter-web` specifies a `httpx` dependency of 0.26.0.
* As of 0.20.0, `httpx` no longer follows redirects by default.
* `spleeter` fails to explicitly request following redirects.

This issue has been called out in an unmerged `spleeter` PR: https://github.com/deezer/spleeter/pull/808 but that has not been merged for a long time.

~One possible solution might be to downgrade the `httpx` dependency to < 0.20.0, but I don't know what other repercussions this could have. The other solution, which I've chosen here, is to fix the `spleeter` code with a patch applied at container build time.~
After discussion of alternatives with @JeffreyCA, this PR pins `httpx` at 0.19.0

