### PR TITLE
Add media recovery page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The app uses [Django](https://www.djangoproject.com/) for the backend API and [R
     - [Environment variables](#environment-variables)
 - [Using cloud storage](#using-cloud-storage-azure-storage-aws-s3-etc)
 - [Deployment](#deployment)
+- [Recovering from a lost database](#recovering-from-a-lost-database)
 - [Common issues & FAQs](#common-issues--faqs)
 - [Credits](#credits)
 - [License](#license)
@@ -327,6 +328,10 @@ If you have `ENABLE_CROSS_ORIGIN_HEADERS` set, then you'll need to additionally 
 ## HTTPS support
 
 Enabling HTTPS allows you to export Dynamic Mixes from your browser. To enable HTTPS, set **both** `CERTBOT_DOMAIN` and `CERTBOT_EMAIL` to your domain name and `CERTBOT_EMAIL` to your email in `.env` and include `-f docker-compose.https.yml` in your `docker-compose up` command.
+
+## Recovering from a lost database
+
+If the database is ever lost but the `media` directory survives, visit `/recovery` (a hidden maintenance page) to scan the media directory and re-import the tracks and mixes into the database on a best-effort basis. Only local file storage is supported, and some metadata (such as YouTube links) cannot be recovered.
 
 ## [Common issues & FAQs](https://github.com/JeffreyCA/spleeter-web/wiki/Common-issues-&-FAQs)
 

--- a/api-entrypoint.sh
+++ b/api-entrypoint.sh
@@ -16,7 +16,7 @@ python3.11 manage.py migrate
 
 echo "Starting server"
 if [[ -z "${DJANGO_DEVELOPMENT}" ]]; then
-    gunicorn -b $API_HOST:8000 django_react.wsgi
+    gunicorn -b $API_HOST:8000 --timeout ${GUNICORN_TIMEOUT:-120} django_react.wsgi
 else
     python3.11 manage.py runserver $API_HOST:8000
 fi

--- a/api/recovery.py
+++ b/api/recovery.py
@@ -371,10 +371,14 @@ def scan_mixes():
 
     lookup = {}
     for track in SourceTrack.objects.all():
-        lookup.setdefault(match_key(track.artist, track.title), {
+        key = match_key(track.artist, track.title)
+        # Several tracks can share a name, and picking one of them arbitrarily
+        # would silently attach mixes to the wrong track, so mark the name as
+        # ambiguous and leave the choice to the user
+        lookup[key] = None if key in lookup else {
             'kind': 'track',
             'id': str(track.id)
-        })
+        }
 
     for name in sorted(os.listdir(separate_root)):
         if not is_uuid(name) or name in existing_ids:
@@ -412,11 +416,14 @@ def perform_scan():
     """
     uploads = scan_uploads()
     mixes = scan_mixes()
+    # The file is what tells two tracks with the same artist and title apart,
+    # so its path is sent along for the source track picker
     existing_tracks = [{
         'id': str(track.id),
         'artist': track.artist,
-        'title': track.title
-    } for track in SourceTrack.objects.all()]
+        'title': track.title,
+        'path': track.source_file.file.name if track.source_file.file else ''
+    } for track in SourceTrack.objects.select_related('source_file').all()]
     return {
         'uploads': uploads,
         'mixes': mixes,

--- a/api/recovery.py
+++ b/api/recovery.py
@@ -52,6 +52,15 @@ DEFAULT_BITRATE = 256
 # Mix output files are only ever MP3/WAV/FLAC (see api.util.output_format_to_ext)
 MIX_FILE_EXTS = frozenset(['.mp3', '.wav', '.flac'])
 
+# settings.VALID_FILE_EXT only covers what users may upload, but uploads/ also holds
+# YouTube downloads, which are named after the format yt-dlp fetched (see
+# api.youtubedl.download_audio). Its audio formats are all upload-legal, but the
+# 'bestaudio/best' fallback can yield a video container, and older downloads were
+# named from a guessed extension that did not always match the file. Those files are
+# already on disk, so recovery reads anything yt-dlp can leave behind.
+UPLOAD_FILE_EXTS = frozenset(settings.VALID_FILE_EXT) | frozenset(
+    ['.mp4', '.m4v', '.mkv', '.mov', '.avi', '.flv', '.3gp'])
+
 # The greedy prefix binds to the *last* "(parts) [suffix]" group, so titles that
 # themselves contain parentheses parse correctly.
 MIX_FILENAME_RE = re.compile(
@@ -250,7 +259,7 @@ def find_upload_file(dir_id):
     :return: File name, or None if the directory has no valid audio file
     """
     dir_path = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR, dir_id)
-    files = list_files_with_ext(dir_path, set(settings.VALID_FILE_EXT))
+    files = list_files_with_ext(dir_path, UPLOAD_FILE_EXTS)
     return files[0] if files else None
 
 

--- a/api/recovery.py
+++ b/api/recovery.py
@@ -1,0 +1,609 @@
+import os
+import re
+import urllib.parse
+import uuid
+from datetime import datetime, timezone
+
+import mutagen
+from django.conf import settings
+from django.db import IntegrityError, transaction
+from mutagen.easyid3 import EasyID3
+
+from .models import (BS_ROFORMER_5S_GUITAR, BS_ROFORMER_5S_PIANO,
+                     BS_ROFORMER_6S, BS_ROFORMER_FAMILY, D3NET, DEMUCS_FAMILY,
+                     SPLEETER, SPLEETER_PIANO, XUMX, DynamicMix, SourceFile,
+                     SourceTrack, StaticMix, TaskStatus)
+from .util import get_valid_filename
+
+"""
+This module implements best-effort recovery of lost database entries from the files
+remaining in the media directory (see GitHub discussion #1968).
+
+Media paths embed the UUID primary keys of their rows (media/uploads/<SourceFile.id>/,
+media/separate/<StaticMix.id or DynamicMix.id>/), and mix filenames encode metadata in
+the format produced by StaticMix.formatted_name()/DynamicMix.formatted_suffix():
+
+    {Artist - Title} ({parts}) [{bitrate display},{separator}{extras}].ext
+
+Parsing is lossy (filenames were sanitized with get_valid_filename), so recovered
+metadata is a best-effort starting point that the user reviews before importing.
+"""
+
+KNOWN_SEPARATORS = frozenset([SPLEETER, SPLEETER_PIANO, D3NET, XUMX] +
+                             BS_ROFORMER_FAMILY + DEMUCS_FAMILY)
+PIANO_SEPARATORS = frozenset(
+    [SPLEETER_PIANO, BS_ROFORMER_5S_PIANO, BS_ROFORMER_6S])
+GUITAR_SEPARATORS = frozenset([BS_ROFORMER_5S_GUITAR, BS_ROFORMER_6S])
+
+STEM_NAMES = frozenset(
+    ['vocals', 'drums', 'bass', 'other', 'piano', 'guitar'])
+STEM_ORDER = ['vocals', 'drums', 'bass', 'piano', 'guitar', 'other']
+
+# Inverse of OutputFormat labels used in mix filename suffixes
+BITRATE_DISPLAY_TO_VALUE = {
+    '192 kbps': 192,
+    '256 kbps': 256,
+    '320 kbps': 320,
+    'WAV': 0,
+    'FLAC': 1
+}
+DEFAULT_BITRATE = 256
+
+# Mix output files are only ever MP3/WAV/FLAC (see api.util.output_format_to_ext)
+MIX_FILE_EXTS = frozenset(['.mp3', '.wav', '.flac'])
+
+# The greedy prefix binds to the *last* "(parts) [suffix]" group, so titles that
+# themselves contain parentheses parse correctly.
+MIX_FILENAME_RE = re.compile(
+    r'^(?P<prefix>.*) \((?P<parts>[a-z,]+)\) \[(?P<suffix>[^\[\]]*)\]\.(?P<ext>[A-Za-z0-9]+)$'
+)
+
+
+def storage_is_local():
+    """Return whether the default file storage is the local filesystem."""
+    return settings.DEFAULT_FILE_STORAGE == 'api.storage.FileSystemStorage'
+
+
+def parse_mix_suffix(suffix):
+    """Parse the bracketed suffix of a mix filename into model fields.
+
+    Tolerates legacy formats found in real media directories (extra trailing
+    tokens, bare-bitrate D3Net suffixes). Always returns a separator from
+    KNOWN_SEPARATORS with separator_args shaped so that get_extra_info() and
+    formatted_name()/formatted_suffix() never raise KeyError. 'normalized' is
+    True when unrecognized values were replaced with defaults.
+
+    :param suffix: Suffix content between brackets, e.g. '256 kbps,htdemucs,0 shifts'
+    :return: Dict with 'separator', 'separator_args', 'bitrate', 'normalized'
+    """
+    tokens = [t.strip() for t in suffix.split(',')] if suffix else []
+    normalized = False
+
+    if tokens and tokens[0] in BITRATE_DISPLAY_TO_VALUE:
+        bitrate = BITRATE_DISPLAY_TO_VALUE[tokens[0]]
+    else:
+        bitrate = DEFAULT_BITRATE
+        normalized = True
+
+    if len(tokens) < 2:
+        # Current D3Net dynamic mix suffixes contain only the bitrate
+        separator = D3NET
+        separator_args = {}
+    else:
+        separator = tokens[1]
+        if separator in DEMUCS_FAMILY:
+            random_shifts = 0
+            for token in tokens[2:]:
+                match = re.fullmatch(r'(\d+) shifts', token)
+                if match:
+                    random_shifts = int(match.group(1))
+            separator_args = {'random_shifts': random_shifts}
+        elif separator == XUMX:
+            iterations = 0
+            softmask = False
+            alpha = 1.0
+            for token in tokens[2:]:
+                match = re.fullmatch(r'(\d+) iter', token)
+                if match:
+                    iterations = int(match.group(1))
+                    continue
+                match = re.fullmatch(r'softmask (\S+)', token)
+                if match:
+                    softmask = True
+                    try:
+                        alpha = float(match.group(1).replace('_', '.'))
+                    except ValueError:
+                        pass
+            separator_args = {
+                'iterations': iterations,
+                'softmask': softmask,
+                'alpha': alpha
+            }
+        elif separator in KNOWN_SEPARATORS:
+            # Ignore trailing tokens (legacy formats like 'spleeter_5stems,1 iter')
+            separator_args = {}
+        else:
+            separator = SPLEETER
+            separator_args = {}
+            normalized = True
+
+    return {
+        'separator': separator,
+        'separator_args': separator_args,
+        'bitrate': bitrate,
+        'normalized': normalized
+    }
+
+
+def parse_mix_filename(filename):
+    """Parse a mix filename into its prefix, parts, and separator information.
+
+    :param filename: Base name of a mix file
+    :return: Dict with 'prefix', 'parts', 'parsed', plus parse_mix_suffix() fields
+    """
+    match = MIX_FILENAME_RE.match(filename)
+    if match:
+        parts = match.group('parts').split(',')
+        if set(parts) <= STEM_NAMES:
+            info = parse_mix_suffix(match.group('suffix'))
+            info.update({
+                'prefix': match.group('prefix'),
+                'parts': parts,
+                'parsed': True
+            })
+            return info
+    return {
+        'prefix': os.path.splitext(filename)[0],
+        'parts': [],
+        'parsed': False,
+        'separator': SPLEETER,
+        'separator_args': {},
+        'bitrate': DEFAULT_BITRATE,
+        'normalized': True
+    }
+
+
+def split_artist_title(prefix):
+    """Split an 'Artist - Title' string on the first separator occurrence.
+
+    :param prefix: Combined artist/title string
+    :return: Tuple of (artist, title); artist is empty if no separator found
+    """
+    if ' - ' in prefix:
+        artist, title = prefix.split(' - ', 1)
+        return artist.strip(), title.strip()
+    return '', prefix.strip()
+
+
+def read_tags(path):
+    """Extract artist and title from a local audio file's tags (best-effort).
+
+    :param path: Absolute or CWD-relative path to the audio file
+    :return: Tuple of (artist, title); empty strings when unavailable
+    """
+    artist = ''
+    title = ''
+    try:
+        audio = EasyID3(path) if path.endswith('mp3') else mutagen.File(path)
+        if audio:
+            if 'artist' in audio:
+                artist = str(audio['artist'][0])
+            if 'title' in audio:
+                title = str(audio['title'][0])
+    except:
+        pass
+    return artist, title
+
+
+def media_file_url(*parts):
+    """Build the URL of a file under MEDIA_URL from its path components."""
+    return settings.MEDIA_URL + '/'.join(
+        urllib.parse.quote(part) for part in parts)
+
+
+def is_uuid(name):
+    """Return whether the given string is a valid UUID."""
+    try:
+        uuid.UUID(name)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def file_mtime(path):
+    """Return the file's modification time as an aware UTC datetime."""
+    return datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+
+
+def list_files_with_ext(dir_path, extensions):
+    """List files in a directory whose extension is in the given set.
+
+    :param dir_path: Directory to list
+    :param extensions: Set of lowercase extensions including the dot
+    :return: Sorted list of matching file names
+    """
+    result = []
+    for name in sorted(os.listdir(dir_path)):
+        if not os.path.isfile(os.path.join(dir_path, name)):
+            continue
+        if os.path.splitext(name)[1].lower() in extensions:
+            result.append(name)
+    return result
+
+
+def find_upload_file(dir_id):
+    """Find the audio file inside an upload directory.
+
+    :param dir_id: Name of the media/uploads subdirectory (a UUID string)
+    :return: File name, or None if the directory has no valid audio file
+    """
+    dir_path = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR, dir_id)
+    if not os.path.isdir(dir_path):
+        return None
+    files = list_files_with_ext(dir_path, set(settings.VALID_FILE_EXT))
+    return files[0] if files else None
+
+
+def parse_mix_dir(dir_id):
+    """Inspect a media/separate subdirectory and parse its contents.
+
+    :param dir_id: Name of the media/separate subdirectory (a UUID string)
+    :return: Dict describing the directory, or None if it has no mix files
+    """
+    dir_path = os.path.join(settings.MEDIA_ROOT, settings.SEPARATE_DIR, dir_id)
+    if not os.path.isdir(dir_path):
+        return None
+    files = list_files_with_ext(dir_path, MIX_FILE_EXTS)
+    if not files:
+        return None
+
+    # Use the first parseable filename for shared metadata
+    parses = [parse_mix_filename(filename) for filename in files]
+    primary = next((p for p in parses if p['parsed']), parses[0])
+
+    # Map stems to files for dynamic mixes
+    stem_files = {}
+    for filename, parse in zip(files, parses):
+        if parse['parsed'] and len(parse['parts']) == 1:
+            stem_files.setdefault(parse['parts'][0], filename)
+
+    if len(files) == 1:
+        mix_type = 'static'
+        parts = primary['parts']
+    else:
+        mix_type = 'dynamic'
+        parts = [stem for stem in STEM_ORDER if stem in stem_files]
+
+    # Default the row-level preview to the accompaniment ('other') stem
+    preview_file = stem_files.get('other') or stem_files.get(
+        'vocals') or files[0]
+
+    return {
+        'preview_url': media_file_url(settings.SEPARATE_DIR, dir_id,
+                                      preview_file),
+        'stem_urls': {
+            stem: media_file_url(settings.SEPARATE_DIR, dir_id, filename)
+            for stem, filename in stem_files.items()
+        } if mix_type == 'dynamic' else {},
+        'type': mix_type,
+        'files': files,
+        'stem_files': stem_files,
+        'parts': parts,
+        'prefix': primary['prefix'],
+        'parsed': primary['parsed'],
+        'normalized': primary['normalized'],
+        'separator': primary['separator'],
+        'separator_args': primary['separator_args'],
+        'bitrate': primary['bitrate'],
+        'date': file_mtime(os.path.join(dir_path, files[0]))
+    }
+
+
+def match_key(artist, title):
+    """Build the lookup key used to match mix filename prefixes to tracks.
+
+    Mix filename prefixes were produced by get_valid_filename('Artist - Title'),
+    so candidate keys are sanitized the same way before comparison.
+    """
+    return get_valid_filename(f'{artist} - {title}').strip().lower()
+
+
+def scan_uploads():
+    """Scan media/uploads for directories not present in the database.
+
+    :return: List of dicts describing recoverable uploads
+    """
+    results = []
+    uploads_root = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR)
+    if not os.path.isdir(uploads_root):
+        return results
+    existing_ids = {
+        str(pk)
+        for pk in SourceFile.objects.values_list('id', flat=True)
+    }
+    for name in sorted(os.listdir(uploads_root)):
+        if not is_uuid(name) or name in existing_ids:
+            continue
+        filename = find_upload_file(name)
+        if filename is None:
+            continue
+        file_path = os.path.join(uploads_root, name, filename)
+        tag_artist, tag_title = read_tags(file_path)
+        fn_artist, fn_title = split_artist_title(os.path.splitext(filename)[0])
+        results.append({
+            'id': name,
+            'filename': filename,
+            'url': media_file_url(settings.UPLOAD_DIR, name, filename),
+            'artist': tag_artist or fn_artist,
+            'title': tag_title or fn_title,
+            'date': file_mtime(file_path).isoformat()
+        })
+    return results
+
+
+def scan_mixes():
+    """Scan media/separate for directories not present in the database.
+
+    Mixes are only matched against tracks that currently exist in the database,
+    so uploads should be recovered first; a rescan will then match their mixes.
+
+    :return: List of dicts describing recoverable mixes
+    """
+    results = []
+    separate_root = os.path.join(settings.MEDIA_ROOT, settings.SEPARATE_DIR)
+    if not os.path.isdir(separate_root):
+        return results
+    existing_ids = {
+        str(pk)
+        for pk in StaticMix.objects.values_list('id', flat=True)
+    } | {
+        str(pk)
+        for pk in DynamicMix.objects.values_list('id', flat=True)
+    }
+
+    lookup = {}
+    for track in SourceTrack.objects.all():
+        lookup.setdefault(match_key(track.artist, track.title), {
+            'kind': 'track',
+            'id': str(track.id)
+        })
+
+    for name in sorted(os.listdir(separate_root)):
+        if not is_uuid(name) or name in existing_ids:
+            continue
+        info = parse_mix_dir(name)
+        if info is None:
+            continue
+        artist, title = split_artist_title(info['prefix'])
+        match = lookup.get(info['prefix'].strip().lower())
+        results.append({
+            'id': name,
+            'type': info['type'],
+            'files': info['files'],
+            'preview_url': info['preview_url'],
+            'stem_urls': info['stem_urls'],
+            'prefix': info['prefix'],
+            'artist': artist,
+            'title': title,
+            'parts': info['parts'],
+            'separator': info['separator'],
+            'separator_args': info['separator_args'],
+            'bitrate': info['bitrate'],
+            'parsed': info['parsed'],
+            'normalized': info['normalized'],
+            'match': match,
+            'date': info['date'].isoformat()
+        })
+    return results
+
+
+def perform_scan():
+    """Scan the media directory for recoverable uploads and mixes.
+
+    :return: Dict with 'uploads', 'mixes', and 'existing_tracks'
+    """
+    uploads = scan_uploads()
+    mixes = scan_mixes()
+    existing_tracks = [{
+        'id': str(track.id),
+        'artist': track.artist,
+        'title': track.title
+    } for track in SourceTrack.objects.all()]
+    return {
+        'uploads': uploads,
+        'mixes': mixes,
+        'existing_tracks': existing_tracks
+    }
+
+
+def import_upload(item):
+    """Import a single upload directory as a SourceFile + SourceTrack.
+
+    :param item: Dict with 'id' and user-reviewed 'artist'/'title'
+    :return: Result dict with 'id', 'status', and optional 'detail'/'track_id'
+    """
+    dir_id = str(item.get('id', ''))
+    if not is_uuid(dir_id):
+        return {'id': dir_id, 'status': 'error', 'detail': 'Invalid ID'}
+    if SourceFile.objects.filter(id=dir_id).exists():
+        return {'id': dir_id, 'status': 'skipped', 'detail': 'Already exists'}
+    filename = find_upload_file(dir_id)
+    if filename is None:
+        return {
+            'id': dir_id,
+            'status': 'error',
+            'detail': 'No audio file found in directory'
+        }
+
+    file_path = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR, dir_id,
+                             filename)
+    artist = str(item.get('artist', '')).strip()
+    title = str(item.get('title', '')).strip()
+    if not title:
+        tag_artist, tag_title = read_tags(file_path)
+        fn_artist, fn_title = split_artist_title(os.path.splitext(filename)[0])
+        artist = artist or tag_artist or fn_artist
+        title = tag_title or fn_title
+
+    try:
+        with transaction.atomic():
+            source_file = SourceFile(id=dir_id, is_youtube=False)
+            # Assign the path directly, like the Celery tasks do
+            source_file.file.name = os.path.join(settings.UPLOAD_DIR, dir_id,
+                                                 filename)
+            source_file.save()
+            track = SourceTrack(source_file=source_file,
+                                artist=artist,
+                                title=title)
+            track.save()
+            # date_created is auto_now_add, so it must be backfilled separately
+            SourceTrack.objects.filter(id=track.id).update(
+                date_created=file_mtime(file_path))
+    except IntegrityError as error:
+        return {'id': dir_id, 'status': 'skipped', 'detail': str(error)}
+    except Exception as error:
+        return {'id': dir_id, 'status': 'error', 'detail': str(error)}
+
+    return {'id': dir_id, 'status': 'imported', 'track_id': str(track.id)}
+
+
+def create_placeholder(item):
+    """Create a placeholder SourceTrack (with an empty SourceFile) for mixes
+    whose original upload no longer exists.
+
+    :param item: Dict with 'artist' and 'title'
+    :return: Result dict with 'id', 'status', and optional 'detail'/'track_id'
+    """
+    artist = str(item.get('artist', '')).strip()
+    title = str(item.get('title', '')).strip()
+    label = f'{artist} - {title}' if artist else title
+    if not title:
+        return {'id': label, 'status': 'error', 'detail': 'Title is required'}
+    if SourceTrack.objects.filter(artist__iexact=artist,
+                                  title__iexact=title).exists():
+        return {
+            'id': label,
+            'status': 'skipped',
+            'detail': 'A track with this name already exists'
+        }
+    try:
+        with transaction.atomic():
+            source_file = SourceFile(is_youtube=False)
+            source_file.save()
+            track = SourceTrack(source_file=source_file,
+                                artist=artist,
+                                title=title)
+            track.save()
+    except Exception as error:
+        return {'id': label, 'status': 'error', 'detail': str(error)}
+    return {'id': label, 'status': 'imported', 'track_id': str(track.id)}
+
+
+def import_mix(item):
+    """Import a single mix directory as a StaticMix or DynamicMix.
+
+    :param item: Dict with 'id' and a 'track' association
+    :return: Result dict with 'id', 'status', and optional 'detail'/'track_id'
+    """
+    dir_id = str(item.get('id', ''))
+    if not is_uuid(dir_id):
+        return {'id': dir_id, 'status': 'error', 'detail': 'Invalid ID'}
+    if StaticMix.objects.filter(id=dir_id).exists() or DynamicMix.objects.filter(
+            id=dir_id).exists():
+        return {'id': dir_id, 'status': 'skipped', 'detail': 'Already exists'}
+    info = parse_mix_dir(dir_id)
+    if info is None:
+        return {
+            'id': dir_id,
+            'status': 'error',
+            'detail': 'No mix files found in directory'
+        }
+
+    association = item.get('track') or {}
+    if association.get('kind') != 'track':
+        return {
+            'id': dir_id,
+            'status': 'error',
+            'detail': 'No source track selected'
+        }
+    track = SourceTrack.objects.filter(
+        id=str(association.get('id', ''))).first()
+    if track is None:
+        return {
+            'id': dir_id,
+            'status': 'error',
+            'detail': 'Associated track not found'
+        }
+
+    try:
+        with transaction.atomic():
+            if info['type'] == 'static':
+                mix = StaticMix(id=dir_id,
+                                celery_id=None,
+                                separator=info['separator'],
+                                separator_args=info['separator_args'],
+                                bitrate=info['bitrate'],
+                                source_track=track,
+                                vocals='vocals' in info['parts'],
+                                drums='drums' in info['parts'],
+                                bass='bass' in info['parts'],
+                                other='other' in info['parts'],
+                                piano=('piano' in info['parts'])
+                                if info['separator'] in PIANO_SEPARATORS else None,
+                                guitar=('guitar' in info['parts'])
+                                if info['separator'] in GUITAR_SEPARATORS else None,
+                                status=TaskStatus.DONE,
+                                error='')
+                mix.file.name = os.path.join(settings.SEPARATE_DIR, dir_id,
+                                             info['files'][0])
+                mix.save()
+                StaticMix.objects.filter(id=dir_id).update(
+                    date_created=info['date'], date_finished=info['date'])
+            else:
+                mix = DynamicMix(id=dir_id,
+                                 celery_id=None,
+                                 separator=info['separator'],
+                                 separator_args=info['separator_args'],
+                                 bitrate=info['bitrate'],
+                                 source_track=track,
+                                 status=TaskStatus.DONE,
+                                 error='')
+                for stem in ['vocals', 'other', 'bass', 'drums', 'piano', 'guitar']:
+                    if stem in info['stem_files']:
+                        getattr(mix, f'{stem}_file').name = os.path.join(
+                            settings.SEPARATE_DIR, dir_id,
+                            info['stem_files'][stem])
+                mix.save()
+                DynamicMix.objects.filter(id=dir_id).update(
+                    date_created=info['date'], date_finished=info['date'])
+    except IntegrityError as error:
+        return {'id': dir_id, 'status': 'skipped', 'detail': str(error)}
+    except Exception as error:
+        return {'id': dir_id, 'status': 'error', 'detail': str(error)}
+
+    return {'id': dir_id, 'status': 'imported', 'track_id': str(track.id)}
+
+
+def perform_import(data):
+    """Import the user-confirmed uploads, placeholder tracks, and mixes.
+
+    Each item is imported in its own transaction; failures are reported per
+    item and never abort the batch. Mixes can only be associated with tracks
+    that already exist in the database, so uploads and placeholder tracks are
+    expected to be created before their mixes.
+
+    :param data: Dict with 'uploads', 'placeholders', and 'mixes' lists
+    :return: Dict with per-item result lists for each of the three
+    """
+    upload_results = [
+        import_upload(item) for item in data.get('uploads', [])
+    ]
+    placeholder_results = [
+        create_placeholder(item) for item in data.get('placeholders', [])
+    ]
+    mix_results = [import_mix(item) for item in data.get('mixes', [])]
+    return {
+        'uploads': upload_results,
+        'placeholders': placeholder_results,
+        'mixes': mix_results
+    }

--- a/api/recovery.py
+++ b/api/recovery.py
@@ -218,16 +218,28 @@ def file_mtime(path):
 def list_files_with_ext(dir_path, extensions):
     """List files in a directory whose extension is in the given set.
 
+    Media directories can live on slow bind mounts (a Docker Desktop host
+    mount, say), where every syscall is expensive, so this checks the
+    extension before asking whether the entry is a file, and uses scandir so
+    that the answer usually comes from the directory listing itself rather
+    than a stat call per entry.
+
     :param dir_path: Directory to list
     :param extensions: Set of lowercase extensions including the dot
     :return: Sorted list of matching file names
     """
     result = []
-    for name in sorted(os.listdir(dir_path)):
-        if not os.path.isfile(os.path.join(dir_path, name)):
-            continue
-        if os.path.splitext(name)[1].lower() in extensions:
-            result.append(name)
+    try:
+        with os.scandir(dir_path) as entries:
+            for entry in entries:
+                if os.path.splitext(entry.name)[1].lower() not in extensions:
+                    continue
+                if entry.is_file():
+                    result.append(entry.name)
+    except OSError:
+        # Missing directory, or a file where a directory was expected
+        return []
+    result.sort()
     return result
 
 
@@ -238,8 +250,6 @@ def find_upload_file(dir_id):
     :return: File name, or None if the directory has no valid audio file
     """
     dir_path = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR, dir_id)
-    if not os.path.isdir(dir_path):
-        return None
     files = list_files_with_ext(dir_path, set(settings.VALID_FILE_EXT))
     return files[0] if files else None
 
@@ -251,8 +261,6 @@ def parse_mix_dir(dir_id):
     :return: Dict describing the directory, or None if it has no mix files
     """
     dir_path = os.path.join(settings.MEDIA_ROOT, settings.SEPARATE_DIR, dir_id)
-    if not os.path.isdir(dir_path):
-        return None
     files = list_files_with_ext(dir_path, MIX_FILE_EXTS)
     if not files:
         return None

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -21,7 +21,7 @@ from .separators.demucs_separator import DemucsSeparator
 from .separators.spleeter_separator import SpleeterSeparator
 from .separators.bs_roformer_separator import BSRoformerSeparator
 from .util import ALL_PARTS, ALL_PARTS_5_PIANO, ALL_PARTS_5_GUITAR, ALL_PARTS_6, output_format_to_ext, get_valid_filename
-from .youtubedl import download_audio, get_file_ext
+from .youtubedl import download_audio
 
 """
 This module defines various Celery tasks used for Spleeter Web.
@@ -296,15 +296,19 @@ def fetch_youtube_audio(source_file_id, fetch_task_id, artist, title, link):
         # Get paths
         directory = os.path.join(settings.MEDIA_ROOT, settings.UPLOAD_DIR,
                                  str(source_file_id))
-        filename = get_valid_filename(artist + ' - ' +
-                                      title) + get_file_ext(link)
+        pathlib.Path(directory).mkdir(parents=True, exist_ok=True)
+        # get_valid_filename strips '%', so the track name cannot be mistaken for a
+        # field of the output template
+        path_template = os.path.join(
+            directory,
+            get_valid_filename(artist + ' - ' + title) + '.%(ext)s')
+
+        # Start download. Only the download knows the real extension, so the paths
+        # that get stored are derived from the file it actually wrote.
+        rel_path = download_audio(link, path_template)
+        filename = os.path.basename(rel_path)
         rel_media_path = os.path.join(settings.UPLOAD_DIR, str(source_file_id),
                                       filename)
-        rel_path = os.path.join(settings.MEDIA_ROOT, rel_media_path)
-        pathlib.Path(directory).mkdir(parents=True, exist_ok=True)
-
-        # Start download
-        download_audio(link, rel_path)
 
         is_local = settings.DEFAULT_FILE_STORAGE == 'api.storage.FileSystemStorage'
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -27,5 +27,7 @@ urlpatterns = [
          views.DynamicMixRetrieveDestroyView.as_view()),
     path('api/task/', views.YTAudioDownloadTaskListView.as_view()),
     path('api/task/<uuid:id>/',
-         views.YTAudioDownloadTaskRetrieveView.as_view())
+         views.YTAudioDownloadTaskRetrieveView.as_view()),
+    path('api/recovery/scan/', views.RecoveryScanView.as_view()),
+    path('api/recovery/import/', views.RecoveryImportView.as_view())
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/api/views.py
+++ b/api/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.cache import cache_page
 from rest_framework import generics, viewsets
 from rest_framework.views import APIView
 
+from . import recovery
 from .celery import app
 from .models import *
 from .serializers import *
@@ -437,3 +438,27 @@ class YTAudioDownloadTaskListView(generics.ListAPIView):
     """View that handles listing YouTube download tasks."""
     queryset = YTAudioDownloadTask.objects.all()
     serializer_class = YTAudioDownloadTaskSerializer
+
+class RecoveryScanView(APIView):
+    """View that scans the media directory for recoverable uploads and mixes."""
+    def get(self, request):
+        if not recovery.storage_is_local():
+            return JsonResponse(
+                {
+                    'status': 'error',
+                    'errors': ['Recovery requires local file storage']
+                },
+                status=400)
+        return JsonResponse(recovery.perform_scan())
+
+class RecoveryImportView(APIView):
+    """View that imports user-confirmed recoverable uploads and mixes."""
+    def post(self, request):
+        if not recovery.storage_is_local():
+            return JsonResponse(
+                {
+                    'status': 'error',
+                    'errors': ['Recovery requires local file storage']
+                },
+                status=400)
+        return JsonResponse(recovery.perform_import(request.data))

--- a/api/youtubedl.py
+++ b/api/youtubedl.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import os
 
 from django.conf import settings
 from yt_dlp import YoutubeDL
@@ -9,35 +8,6 @@ from youtube_title_parse import get_artist_title
 """
 This module contains functions related to downloading/parsing YouTube links with youtubedl.
 """
-
-def get_file_ext(url):
-    """
-    Get the file extension of the audio file that would be extracted from the
-    given YouTube video URL.
-
-    :param url: YouTube video URL
-    """
-    opts = {
-    # Always use the best audio quality available
-        'format': 'bestaudio/best',
-        'forcefilename': True,
-        'noplaylist': True,
-        'source_address': settings.YOUTUBEDL_SOURCE_ADDR,
-        'verbose': settings.YOUTUBEDL_VERBOSE,
-        'remote_components': ['ejs:github', 'ejs:npm']
-    }
-    # Try up to 3 times as youtubedl tends to be flakey
-    for _ in range(settings.YOUTUBE_MAX_RETRIES):
-        try:
-            with YoutubeDL(opts) as ydl:
-                info = ydl.extract_info(url, download=False)
-                filename = ydl.prepare_filename(info)
-                _, file_extension = os.path.splitext(filename)
-                return file_extension
-        except DownloadError:
-            # Allow for retry
-            pass
-    raise Exception('get_file_ext failed')
 
 def get_meta_info(url):
     """
@@ -97,17 +67,20 @@ def get_meta_info(url):
             pass
     raise DownloadError('Unable to parse YouTube link')
 
-def download_audio(url, dir_path):
+def download_audio(url, path_template):
     """
     Extract audio track from YouTube video and save to given path.
 
     :param url: YouTube video URL
-    :param dir_path: Path to save audio file
+    :param path_template: Output template for the audio file. Must end in '%(ext)s'
+                          so the file is named after the format that is actually
+                          downloaded (see the return value).
+    :return: Path of the file that was written
     """
     opts = {
         'format': 'bestaudio/best',
         'forcefilename': True,
-        'outtmpl': str(dir_path),
+        'outtmpl': str(path_template),
         'cachedir': False,
         'noplaylist': True,
         'source_address': settings.YOUTUBEDL_SOURCE_ADDR,
@@ -120,4 +93,10 @@ def download_audio(url, dir_path):
         info = ydl.extract_info(url, download=False)
         if info['duration'] > settings.YOUTUBE_LENGTH_LIMIT:
             raise Exception('Video length too long')
-        ydl.download([url])
+        # The format is picked per extraction and can differ between calls, so only
+        # the download itself can say what was written and under which extension
+        info = ydl.extract_info(url)
+        downloads = info.get('requested_downloads') or []
+        if downloads and downloads[0].get('filepath'):
+            return downloads[0]['filepath']
+        return ydl.prepare_filename(info)

--- a/frontend/src/components/Recovery/Recovery.css
+++ b/frontend/src/components/Recovery/Recovery.css
@@ -7,3 +7,36 @@
   color: #adb5bd;
   margin-left: 0.25rem;
 }
+
+.recovery-track-choice {
+  max-width: 18rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.recovery-track-list {
+  max-height: 55vh;
+  overflow-y: auto;
+}
+
+.recovery-track-path {
+  color: #6c757d;
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+  word-break: break-all;
+}
+
+.recovery-track-list .active .recovery-track-path {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.recovery-copy {
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.recovery-copy:hover {
+  opacity: 1;
+}

--- a/frontend/src/components/Recovery/Recovery.css
+++ b/frontend/src/components/Recovery/Recovery.css
@@ -1,0 +1,9 @@
+.recovery-editable {
+  border-bottom: 1px dashed #adb5bd;
+  cursor: pointer;
+}
+
+.recovery-editable .recovery-edit-icon {
+  color: #adb5bd;
+  margin-left: 0.25rem;
+}

--- a/frontend/src/components/Recovery/Recovery.tsx
+++ b/frontend/src/components/Recovery/Recovery.tsx
@@ -618,11 +618,13 @@ class Recovery extends React.Component<Record<string, never>, State> {
         <Container className="mt-4 mb-5">
           <h2>Media Recovery</h2>
           <p className="text-muted">
-            Recover missing database entries from files in the media directory, on a best-effort basis. Import the
-            uploads first, then the separated mixes - a mix can only be assigned to a track that already exists. If a
-            mix&apos;s original upload is gone, create a placeholder track for it from the Uploads tab. Use the play
-            buttons to preview files (or individual stems) by ear, and click underlined fields to fix metadata before
-            importing. Everything can still be edited later on the main page.
+            If the database was lost or reset, this page rebuilds its entries from the audio files still in the media
+            directory.
+          </p>
+          <p className="text-muted">
+            Import uploads first, then mixes (a mix can only be assigned to a track that already exists). If a
+            mix&apos;s upload is gone, add a placeholder track for it in the Uploads tab. Click any underlined field to
+            correct it before importing, or edit it later on the main page.
           </p>
           {scanErrors.length > 0 && (
             <Alert variant="danger">

--- a/frontend/src/components/Recovery/Recovery.tsx
+++ b/frontend/src/components/Recovery/Recovery.tsx
@@ -262,10 +262,14 @@ class Recovery extends React.Component<Record<string, never>, State> {
     const { existingTracks } = this.state;
     return [
       { value: '', label: 'Select a track...' },
-      ...existingTracks.map(track => ({
-        value: `track:${track.id}`,
-        label: `${track.artist ? `${track.artist} - ` : ''}${track.title}`,
-      })),
+      // Sorted, because this list can run to hundreds of entries and is
+      // otherwise in database insertion order
+      ...existingTracks
+        .map(track => ({
+          value: `track:${track.id}`,
+          label: `${track.artist ? `${track.artist} - ` : ''}${track.title}`,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
     ];
   };
 
@@ -379,24 +383,10 @@ class Recovery extends React.Component<Record<string, never>, State> {
       },
     ];
 
-    // When a source track is selected, mirror that track's metadata so the cells
-    // always show what the mix will actually get; otherwise show the values
-    // inferred from the filename as a hint of what the mix is.
-    const existingTrackById: { [id: string]: RecoveryTrackRef } = {};
-    this.state.existingTracks.forEach(track => (existingTrackById[track.id] = track));
-    // eslint-disable-next-line react/display-name
-    const mixMetadataFormatter = (field: 'artist' | 'title') => (cell: string, row: RecoveryMix) => {
-      const track = existingTrackById[row.track.split(':')[1]];
-      return track ? (
-        <span className="text-muted" title="Comes from the selected source track">
-          {track[field]}
-        </span>
-      ) : (
-        <span className="text-muted font-italic" title="Inferred from the file name">
-          {cell}
-        </span>
-      );
-    };
+    // These always describe the mix file itself, never the selected source track.
+    // They are what identifies the row, and what makes a wrong assignment visible
+    // when compared against the Source track column.
+    const mixMetadataFormatter = (cell: string) => <span title="Read from the mix file name">{cell}</span>;
 
     const mixColumns: ColumnDescription<RecoveryMix>[] = [
       {
@@ -438,14 +428,14 @@ class Recovery extends React.Component<Record<string, never>, State> {
       {
         dataField: 'artist',
         editable: false,
-        text: 'Artist',
-        formatter: mixMetadataFormatter('artist'),
+        text: 'Mix artist',
+        formatter: mixMetadataFormatter,
       },
       {
         dataField: 'title',
         editable: false,
-        text: 'Title',
-        formatter: mixMetadataFormatter('title'),
+        text: 'Mix title',
+        formatter: mixMetadataFormatter,
       },
       {
         dataField: 'track',

--- a/frontend/src/components/Recovery/Recovery.tsx
+++ b/frontend/src/components/Recovery/Recovery.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import * as React from 'react';
-import { Alert, Badge, Button, Container, Form, Spinner, Tab, Tabs } from 'react-bootstrap';
-import { PauseFill, Pencil, PlayFill } from 'react-bootstrap-icons';
+import { Alert, Badge, Button, Container, Form, ListGroup, Modal, Spinner, Tab, Tabs } from 'react-bootstrap';
+import { Clipboard, ClipboardCheck, PauseFill, Pencil, PlayFill } from 'react-bootstrap-icons';
 import BootstrapTable, { ColumnDescription, SelectRowProps } from 'react-bootstrap-table-next';
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
 import cellEditFactory from 'react-bootstrap-table2-editor';
@@ -61,6 +61,11 @@ interface State {
   activeTab: string;
   placeholderArtist: string;
   placeholderTitle: string;
+  // Mix whose source track is being chosen in the picker modal, if any
+  pickerMixId?: string;
+  pickerFilter: string;
+  // Path most recently copied from the picker, briefly shown with a checkmark
+  copiedPath?: string;
 }
 
 /**
@@ -70,6 +75,8 @@ interface State {
  */
 class Recovery extends React.Component<Record<string, never>, State> {
   audio: HTMLAudioElement;
+  pickerSearchRef = React.createRef<HTMLInputElement>();
+  copyResetTimer?: number;
 
   constructor(props: Record<string, never>) {
     super(props);
@@ -90,6 +97,9 @@ class Recovery extends React.Component<Record<string, never>, State> {
       activeTab: 'uploads',
       placeholderArtist: '',
       placeholderTitle: '',
+      pickerMixId: undefined,
+      pickerFilter: '',
+      copiedPath: undefined,
     };
   }
 
@@ -99,6 +109,7 @@ class Recovery extends React.Component<Record<string, never>, State> {
 
   componentWillUnmount(): void {
     this.audio.pause();
+    window.clearTimeout(this.copyResetTimer);
   }
 
   stopPlayback = (): void => {
@@ -228,6 +239,49 @@ class Recovery extends React.Component<Record<string, never>, State> {
     this.setState({ activeTab: tab ?? 'uploads' });
   };
 
+  openPicker = (mixId: string): void => {
+    this.setState({ pickerMixId: mixId, pickerFilter: '' });
+  };
+
+  closePicker = (): void => {
+    this.setState({ pickerMixId: undefined });
+  };
+
+  pickTrack = (value: string): void => {
+    if (this.state.pickerMixId) {
+      this.onTrackChoiceChange(this.state.pickerMixId, value);
+    }
+    this.closePicker();
+  };
+
+  focusPickerSearch = (): void => {
+    this.pickerSearchRef.current?.focus();
+  };
+
+  // navigator.clipboard needs a secure context, and this page may well be
+  // served over plain http
+  copyViaTextarea = (path: string): void => {
+    const textarea = document.createElement('textarea');
+    textarea.value = path;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  };
+
+  copyPath = (path: string, event: React.MouseEvent): void => {
+    // The copy icon sits inside the clickable list entry; don't pick the track
+    event.stopPropagation();
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(path).catch(() => this.copyViaTextarea(path));
+    } else {
+      this.copyViaTextarea(path);
+    }
+    this.setState({ copiedPath: path });
+    window.clearTimeout(this.copyResetTimer);
+    this.copyResetTimer = window.setTimeout(() => this.setState({ copiedPath: undefined }), 1500);
+  };
+
   onTrackChoiceChange = (mixId: string, value: string): void => {
     // Replace the row object so the table repaints the whole row, including the
     // artist/title cells whose editability depends on this choice
@@ -258,7 +312,7 @@ class Recovery extends React.Component<Record<string, never>, State> {
     this.setState({ selectedMixIds: isSelected ? rows.map(row => row.id) : [] });
   };
 
-  trackChoiceOptions = (): Array<{ value: string; label: string; title: string }> => {
+  trackChoiceOptions = (): Array<{ value: string; label: string; path: string }> => {
     const { existingTracks } = this.state;
     const trackName = (track: RecoveryTrackRef) => `${track.artist ? `${track.artist} - ` : ''}${track.title}`;
     const countBy = (values: string[]) => {
@@ -267,33 +321,90 @@ class Recovery extends React.Component<Record<string, never>, State> {
       return counts;
     };
 
-    // Tracks that share a name are indistinguishable by name alone, so those
-    // spell out the file they came from. The same file can also be uploaded
-    // twice, so anything still ambiguous falls back to part of the track ID.
-    const nameCounts = countBy(existingTracks.map(trackName));
-    const labelled = existingTracks.map(track => {
-      const name = trackName(track);
-      const file = track.path.split('/').pop() || 'no file';
-      return {
-        value: `track:${track.id}`,
-        label: nameCounts[name] > 1 ? `${name}  [${file}]` : name,
-        title: track.path || 'no file',
-      };
-    });
-    const labelCounts = countBy(labelled.map(option => option.label));
+    // The file path shown with every entry is what tells tracks with the same
+    // name apart. The same file can also be uploaded twice, so entries whose
+    // name and path both collide get part of the track ID appended.
+    const identityCounts = countBy(existingTracks.map(track => `${trackName(track)} ${track.path}`));
+    // Sorted, because this list can run to hundreds of entries and is
+    // otherwise in database insertion order
+    return existingTracks
+      .map(track => {
+        const name = trackName(track);
+        return {
+          value: `track:${track.id}`,
+          label: identityCounts[`${name} ${track.path}`] > 1 ? `${name}  #${track.id.slice(0, 8)}` : name,
+          path: track.path,
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label) || a.path.localeCompare(b.path));
+  };
 
-    return [
-      { value: '', label: 'Select a track...', title: '' },
-      // Sorted, because this list can run to hundreds of entries and is
-      // otherwise in database insertion order
-      ...labelled
-        .map(option =>
-          labelCounts[option.label] > 1
-            ? { ...option, label: `${option.label}  #${option.value.slice(6, 14)}` }
-            : option
-        )
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    ];
+  // One shared modal serves every row's source track picker: it filters as the
+  // user types, which beats scrolling a native dropdown of hundreds of tracks,
+  // and it avoids rendering the full track list once per table row
+  renderTrackPicker = (trackOptions: Array<{ value: string; label: string; path: string }>): JSX.Element => {
+    const { pickerMixId, pickerFilter, mixes } = this.state;
+    const mix = mixes.find(mix => mix.id === pickerMixId);
+    const tokens = pickerFilter.toLowerCase().split(/\s+/).filter(Boolean);
+    const visibleOptions = trackOptions.filter(option =>
+      tokens.every(token => `${option.label} ${option.path}`.toLowerCase().includes(token))
+    );
+    return (
+      <Modal show={!!mix} onHide={this.closePicker} onEntered={this.focusPickerSearch}>
+        <Modal.Header closeButton>
+          <Modal.Title as="h6">Source track for: {mix?.prefix}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Control
+            ref={this.pickerSearchRef}
+            placeholder="Search by name or file..."
+            value={pickerFilter}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              this.setState({ pickerFilter: event.target.value })
+            }
+            onKeyDown={(event: React.KeyboardEvent) => {
+              if (event.key === 'Enter' && visibleOptions.length === 1) {
+                this.pickTrack(visibleOptions[0].value);
+              }
+            }}
+          />
+          {visibleOptions.length === 0 ? (
+            <p className="text-muted mt-3 mb-0">No tracks match.</p>
+          ) : (
+            <ListGroup className="recovery-track-list mt-3">
+              {visibleOptions.map(option => (
+                <ListGroup.Item
+                  action
+                  key={option.value}
+                  active={mix?.track === option.value}
+                  onClick={() => this.pickTrack(option.value)}>
+                  {option.label}
+                  <small className="recovery-track-path d-block">
+                    {option.path || 'no file'}
+                    {option.path && (
+                      <span
+                        className="recovery-copy ml-1"
+                        title="Copy file path"
+                        onClick={event => this.copyPath(option.path, event)}>
+                        {this.state.copiedPath === option.path ? <ClipboardCheck size={12} /> : <Clipboard size={12} />}
+                      </span>
+                    )}
+                  </small>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </Modal.Body>
+        <Modal.Footer className="justify-content-between">
+          <span className="text-muted small">
+            {visibleOptions.length} of {trackOptions.length} tracks
+          </span>
+          <Button variant="outline-danger" size="sm" disabled={!mix?.track} onClick={() => this.pickTrack('')}>
+            Clear selection
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
   };
 
   renderResults = (): JSX.Element | null => {
@@ -371,6 +482,8 @@ class Recovery extends React.Component<Record<string, never>, State> {
   render(): JSX.Element {
     const { isLoaded, scanErrors, uploads, mixes, selectedUploadIds, selectedMixIds, importing } = this.state;
     const trackOptions = this.trackChoiceOptions();
+    const trackOptionByValue: { [value: string]: { label: string; path: string } } = {};
+    trackOptions.forEach(option => (trackOptionByValue[option.value] = option));
 
     const uploadColumns: ColumnDescription<RecoveryUpload>[] = [
       {
@@ -465,19 +578,14 @@ class Recovery extends React.Component<Record<string, never>, State> {
         editable: false,
         text: 'Source track',
         formatter: (cell: string, row: RecoveryMix) => (
-          <Form.Control
-            as="select"
+          <Button
+            variant={cell ? 'outline-secondary' : 'outline-primary'}
             size="sm"
-            value={cell}
-            onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-              this.onTrackChoiceChange(row.id, event.target.value)
-            }>
-            {trackOptions.map(option => (
-              <option key={option.value} value={option.value} title={option.title}>
-                {option.label}
-              </option>
-            ))}
-          </Form.Control>
+            className="recovery-track-choice"
+            title={cell ? trackOptionByValue[cell]?.path : undefined}
+            onClick={() => this.openPicker(row.id)}>
+            {cell ? trackOptionByValue[cell]?.label ?? cell : 'Select a track...'}
+          </Button>
         ),
       },
       {
@@ -611,6 +719,7 @@ class Recovery extends React.Component<Record<string, never>, State> {
                   )}
                 </Tab>
               </Tabs>
+              {this.renderTrackPicker(trackOptions)}
             </div>
           )}
         </Container>

--- a/frontend/src/components/Recovery/Recovery.tsx
+++ b/frontend/src/components/Recovery/Recovery.tsx
@@ -1,0 +1,609 @@
+import axios from 'axios';
+import * as React from 'react';
+import { Alert, Badge, Button, Container, Form, Spinner, Tab, Tabs } from 'react-bootstrap';
+import { PauseFill, Pencil, PlayFill } from 'react-bootstrap-icons';
+import BootstrapTable, { ColumnDescription, SelectRowProps } from 'react-bootstrap-table-next';
+import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
+import cellEditFactory from 'react-bootstrap-table2-editor';
+import './Recovery.css';
+import {
+  RecoveryImportResponse,
+  RecoveryImportResult,
+  RecoveryMix,
+  RecoveryScanResponse,
+  RecoveryTrackRef,
+  RecoveryUpload,
+} from '../../models/Recovery';
+import { toRelativeDateSpan } from '../../Utils';
+import PlainNavBar from '../Nav/PlainNavBar';
+
+const BITRATE_LABELS: { [bitrate: number]: string } = {
+  0: 'WAV',
+  1: 'FLAC',
+  192: '192 kbps',
+  256: '256 kbps',
+  320: '320 kbps',
+};
+
+const nonEmptyValidator = (newValue: string) => {
+  if (!newValue) {
+    return {
+      valid: false,
+      message: 'Cannot be empty.',
+    };
+  }
+  return true;
+};
+
+/**
+ * Render an editable cell with a dashed underline and pencil icon so it is
+ * apparent which fields can be clicked to edit.
+ */
+const editableCell = (value: string): JSX.Element => (
+  <span className="recovery-editable">
+    {value || <em>none</em>}
+    <Pencil size={12} className="recovery-edit-icon" />
+  </span>
+);
+
+interface State {
+  isLoaded: boolean;
+  scanErrors: string[];
+  uploads: RecoveryUpload[];
+  mixes: RecoveryMix[];
+  existingTracks: RecoveryTrackRef[];
+  selectedUploadIds: string[];
+  selectedMixIds: string[];
+  importing: boolean;
+  importResults?: RecoveryImportResponse;
+  resultLabels: { [id: string]: string };
+  playingUrl?: string;
+  activeTab: string;
+  placeholderArtist: string;
+  placeholderTitle: string;
+}
+
+/**
+ * Hidden maintenance page (not linked from the UI) that scans the media directory for
+ * uploads and mixes missing from the database and re-imports them on a best-effort basis.
+ * Used to recover from database loss when the media files survived.
+ */
+class Recovery extends React.Component<Record<string, never>, State> {
+  audio: HTMLAudioElement;
+
+  constructor(props: Record<string, never>) {
+    super(props);
+    this.audio = new Audio();
+    this.audio.onended = () => this.setState({ playingUrl: undefined });
+    this.state = {
+      isLoaded: false,
+      scanErrors: [],
+      uploads: [],
+      mixes: [],
+      existingTracks: [],
+      selectedUploadIds: [],
+      selectedMixIds: [],
+      importing: false,
+      importResults: undefined,
+      resultLabels: {},
+      playingUrl: undefined,
+      activeTab: 'uploads',
+      placeholderArtist: '',
+      placeholderTitle: '',
+    };
+  }
+
+  componentDidMount(): void {
+    this.loadScan();
+  }
+
+  componentWillUnmount(): void {
+    this.audio.pause();
+  }
+
+  stopPlayback = (): void => {
+    this.audio.pause();
+    this.setState({ playingUrl: undefined });
+  };
+
+  togglePlay = (url: string): void => {
+    if (this.state.playingUrl === url) {
+      this.stopPlayback();
+    } else {
+      this.audio.src = url;
+      this.audio.play().catch(() => this.setState({ playingUrl: undefined }));
+      this.setState({ playingUrl: url });
+    }
+  };
+
+  loadScan = (): void => {
+    this.stopPlayback();
+    this.setState({ isLoaded: false, scanErrors: [] });
+    axios
+      .get<RecoveryScanResponse>('/api/recovery/scan/')
+      .then(({ data }) => {
+        // Rescans happen after every import; carry over the user's in-progress
+        // edits, track choices, and deselections for rows that are still listed
+        const prevUploads = new Map(this.state.uploads.map(upload => [upload.id, upload]));
+        const prevMixes = new Map(this.state.mixes.map(mix => [mix.id, mix]));
+        const prevSelectedUploads = new Set(this.state.selectedUploadIds);
+        const prevSelectedMixes = new Set(this.state.selectedMixIds);
+
+        const uploads: RecoveryUpload[] = data.uploads.map(upload => {
+          const prev = prevUploads.get(upload.id);
+          return prev ? { ...upload, artist: prev.artist, title: prev.title } : upload;
+        });
+        const mixes: RecoveryMix[] = data.mixes.map(mix => {
+          const prev = prevMixes.get(mix.id);
+          const matchedTrack = mix.match ? `track:${mix.match.id}` : '';
+          return { ...mix, track: prev && prev.track ? prev.track : matchedTrack };
+        });
+        this.setState({
+          isLoaded: true,
+          uploads: uploads,
+          mixes: mixes,
+          existingTracks: data.existing_tracks,
+          selectedUploadIds: uploads
+            .map(upload => upload.id)
+            .filter(id => !prevUploads.has(id) || prevSelectedUploads.has(id)),
+          selectedMixIds: mixes.map(mix => mix.id).filter(id => !prevMixes.has(id) || prevSelectedMixes.has(id)),
+          // Uploads should be recovered first, so advance to mixes once none
+          // remain - but never pull the user back from the mixes tab
+          activeTab: this.state.activeTab === 'uploads' && data.uploads.length === 0 ? 'mixes' : this.state.activeTab,
+        });
+      })
+      .catch(error => {
+        const errors = error.response?.data?.errors ?? ['Could not scan the media directory.'];
+        this.setState({ isLoaded: true, scanErrors: errors });
+      });
+  };
+
+  postImport = (payload: Record<string, unknown>, resultLabels: { [id: string]: string }): void => {
+    this.setState({ importing: true });
+    axios
+      .post<RecoveryImportResponse>('/api/recovery/import/', payload)
+      .then(({ data }) => {
+        this.setState({ importing: false, importResults: data, resultLabels: resultLabels });
+        this.loadScan();
+      })
+      .catch(error => {
+        const errors = error.response?.data?.errors ?? ['Import failed.'];
+        this.setState({ importing: false, scanErrors: errors });
+      });
+  };
+
+  handleImportUploads = (): void => {
+    const { uploads, selectedUploadIds } = this.state;
+    const selectedUploads = uploads.filter(upload => selectedUploadIds.includes(upload.id));
+
+    // Remember row descriptions so import results stay readable after rescan
+    const resultLabels: { [id: string]: string } = {};
+    selectedUploads.forEach(upload => (resultLabels[upload.id] = upload.filename));
+
+    this.postImport(
+      {
+        uploads: selectedUploads.map(upload => ({
+          id: upload.id,
+          artist: upload.artist,
+          title: upload.title,
+        })),
+      },
+      resultLabels
+    );
+  };
+
+  handleImportMixes = (): void => {
+    const importableMixes = this.importableMixes();
+
+    const resultLabels: { [id: string]: string } = {};
+    importableMixes.forEach(mix => (resultLabels[mix.id] = `${mix.prefix} (${mix.type})`));
+
+    this.postImport(
+      {
+        mixes: importableMixes.map(mix => ({
+          id: mix.id,
+          track: { kind: 'track', id: mix.track.split(':')[1] },
+        })),
+      },
+      resultLabels
+    );
+  };
+
+  handleCreatePlaceholder = (): void => {
+    const artist = this.state.placeholderArtist.trim();
+    const title = this.state.placeholderTitle.trim();
+    const label = artist ? `${artist} - ${title}` : title;
+    this.setState({ placeholderArtist: '', placeholderTitle: '' });
+    this.postImport({ placeholders: [{ artist, title }] }, { [label]: `Placeholder track: ${label}` });
+  };
+
+  // Selected mixes that have a source track chosen; only these can be imported
+  importableMixes = (): RecoveryMix[] => {
+    const { mixes, selectedMixIds } = this.state;
+    return mixes.filter(mix => selectedMixIds.includes(mix.id) && mix.track !== '');
+  };
+
+  onTabSelect = (tab: string | null): void => {
+    this.stopPlayback();
+    this.setState({ activeTab: tab ?? 'uploads' });
+  };
+
+  onTrackChoiceChange = (mixId: string, value: string): void => {
+    // Replace the row object so the table repaints the whole row, including the
+    // artist/title cells whose editability depends on this choice
+    this.setState(state => ({
+      mixes: state.mixes.map(mix => (mix.id === mixId ? { ...mix, track: value } : mix)),
+    }));
+  };
+
+  onUploadSelect = (row: RecoveryUpload, isSelected: boolean): void => {
+    this.setState(state => ({
+      selectedUploadIds: isSelected
+        ? [...state.selectedUploadIds, row.id]
+        : state.selectedUploadIds.filter(id => id !== row.id),
+    }));
+  };
+
+  onUploadSelectAll = (isSelected: boolean, rows: RecoveryUpload[]): void => {
+    this.setState({ selectedUploadIds: isSelected ? rows.map(row => row.id) : [] });
+  };
+
+  onMixSelect = (row: RecoveryMix, isSelected: boolean): void => {
+    this.setState(state => ({
+      selectedMixIds: isSelected ? [...state.selectedMixIds, row.id] : state.selectedMixIds.filter(id => id !== row.id),
+    }));
+  };
+
+  onMixSelectAll = (isSelected: boolean, rows: RecoveryMix[]): void => {
+    this.setState({ selectedMixIds: isSelected ? rows.map(row => row.id) : [] });
+  };
+
+  trackChoiceOptions = (): Array<{ value: string; label: string }> => {
+    const { existingTracks } = this.state;
+    return [
+      { value: '', label: 'Select a track...' },
+      ...existingTracks.map(track => ({
+        value: `track:${track.id}`,
+        label: `${track.artist ? `${track.artist} - ` : ''}${track.title}`,
+      })),
+    ];
+  };
+
+  renderResults = (): JSX.Element | null => {
+    const { importResults, resultLabels } = this.state;
+    if (!importResults) {
+      return null;
+    }
+    const results: RecoveryImportResult[] = [
+      ...importResults.uploads,
+      ...(importResults.placeholders ?? []),
+      ...importResults.mixes,
+    ];
+    const numImported = results.filter(result => result.status === 'imported').length;
+    const variantMap = { imported: 'success', skipped: 'warning', error: 'danger' } as const;
+    return (
+      <Alert variant={numImported === results.length ? 'success' : 'warning'}>
+        <Alert.Heading>
+          Imported {numImported} of {results.length} items
+        </Alert.Heading>
+        <ul className="mb-0">
+          {results.map(result => (
+            <li key={result.id}>
+              <Badge variant={variantMap[result.status]}>{result.status}</Badge> {resultLabels[result.id] ?? result.id}
+              {result.detail ? ` - ${result.detail}` : ''}
+            </li>
+          ))}
+        </ul>
+      </Alert>
+    );
+  };
+
+  renderPlayButton = (url: string): JSX.Element => {
+    const isPlaying = this.state.playingUrl === url;
+    return (
+      <Button variant="link" size="sm" className="p-0" title="Preview" onClick={() => this.togglePlay(url)}>
+        {isPlaying ? <PauseFill size={22} /> : <PlayFill size={22} />}
+      </Button>
+    );
+  };
+
+  renderParts = (parts: string[], row: RecoveryMix): JSX.Element => {
+    return (
+      <span>
+        {parts.map((part, index) => {
+          const url = row.stem_urls[part];
+          const separator = index < parts.length - 1 ? ', ' : '';
+          if (!url) {
+            return (
+              <span key={part}>
+                {part}
+                {separator}
+              </span>
+            );
+          }
+          const isPlaying = this.state.playingUrl === url;
+          return (
+            <span key={part}>
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0 align-baseline"
+                title={`Preview ${part} stem`}
+                onClick={() => this.togglePlay(url)}>
+                {part}
+                {isPlaying && <PauseFill size={14} />}
+              </Button>
+              {separator}
+            </span>
+          );
+        })}
+      </span>
+    );
+  };
+
+  render(): JSX.Element {
+    const { isLoaded, scanErrors, uploads, mixes, selectedUploadIds, selectedMixIds, importing } = this.state;
+    const trackOptions = this.trackChoiceOptions();
+
+    const uploadColumns: ColumnDescription<RecoveryUpload>[] = [
+      {
+        dataField: 'url',
+        editable: false,
+        text: '',
+        formatter: (cell: string) => this.renderPlayButton(cell),
+        // Changing formatExtraData is what makes the table repaint the play/pause
+        // icons on playback changes; cells are memoized otherwise
+        formatExtraData: this.state.playingUrl,
+        headerStyle: () => ({ width: '40px' }),
+      },
+      { dataField: 'filename', editable: false, text: 'File' },
+      {
+        dataField: 'artist',
+        editable: true,
+        text: 'Artist',
+        validator: nonEmptyValidator,
+        formatter: (cell: string) => editableCell(cell),
+      },
+      {
+        dataField: 'title',
+        editable: true,
+        text: 'Title',
+        validator: nonEmptyValidator,
+        formatter: (cell: string) => editableCell(cell),
+      },
+      {
+        dataField: 'date',
+        editable: false,
+        text: 'Date',
+        formatter: (cell: string) => toRelativeDateSpan(cell),
+      },
+    ];
+
+    // When a source track is selected, mirror that track's metadata so the cells
+    // always show what the mix will actually get; otherwise show the values
+    // inferred from the filename as a hint of what the mix is.
+    const existingTrackById: { [id: string]: RecoveryTrackRef } = {};
+    this.state.existingTracks.forEach(track => (existingTrackById[track.id] = track));
+    // eslint-disable-next-line react/display-name
+    const mixMetadataFormatter = (field: 'artist' | 'title') => (cell: string, row: RecoveryMix) => {
+      const track = existingTrackById[row.track.split(':')[1]];
+      return track ? (
+        <span className="text-muted" title="Comes from the selected source track">
+          {track[field]}
+        </span>
+      ) : (
+        <span className="text-muted font-italic" title="Inferred from the file name">
+          {cell}
+        </span>
+      );
+    };
+
+    const mixColumns: ColumnDescription<RecoveryMix>[] = [
+      {
+        dataField: 'preview_url',
+        editable: false,
+        text: '',
+        formatter: (cell: string) => this.renderPlayButton(cell),
+        formatExtraData: this.state.playingUrl,
+        headerStyle: () => ({ width: '40px' }),
+      },
+      {
+        dataField: 'type',
+        editable: false,
+        text: 'Type',
+        formatter: (cell: string) => <span>{cell === 'static' ? 'Static' : 'Dynamic'}</span>,
+      },
+      {
+        dataField: 'separator',
+        editable: false,
+        text: 'Separator',
+        formatter: (cell: string, row: RecoveryMix) => (
+          <span>
+            {cell} ({BITRATE_LABELS[row.bitrate] ?? row.bitrate})
+            {(row.normalized || !row.parsed) && (
+              <Badge variant="warning" className="ml-1">
+                best effort
+              </Badge>
+            )}
+          </span>
+        ),
+      },
+      {
+        dataField: 'parts',
+        editable: false,
+        text: 'Parts',
+        formatter: (cell: string[], row: RecoveryMix) => this.renderParts(cell, row),
+        formatExtraData: this.state.playingUrl,
+      },
+      {
+        dataField: 'artist',
+        editable: false,
+        text: 'Artist',
+        formatter: mixMetadataFormatter('artist'),
+      },
+      {
+        dataField: 'title',
+        editable: false,
+        text: 'Title',
+        formatter: mixMetadataFormatter('title'),
+      },
+      {
+        dataField: 'track',
+        editable: false,
+        text: 'Source track',
+        formatter: (cell: string, row: RecoveryMix) => (
+          <Form.Control
+            as="select"
+            size="sm"
+            value={cell}
+            onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+              this.onTrackChoiceChange(row.id, event.target.value)
+            }>
+            {trackOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Form.Control>
+        ),
+      },
+      {
+        dataField: 'date',
+        editable: false,
+        text: 'Date',
+        formatter: (cell: string) => toRelativeDateSpan(cell),
+      },
+    ];
+
+    const uploadSelectRow: SelectRowProps<RecoveryUpload> = {
+      mode: 'checkbox',
+      selected: selectedUploadIds,
+      onSelect: this.onUploadSelect,
+      onSelectAll: this.onUploadSelectAll,
+    };
+
+    const mixSelectRow: SelectRowProps<RecoveryMix> = {
+      mode: 'checkbox',
+      selected: selectedMixIds,
+      onSelect: this.onMixSelect,
+      onSelectAll: this.onMixSelectAll,
+    };
+
+    const numImportableMixes = this.importableMixes().length;
+
+    return (
+      <div>
+        <PlainNavBar />
+        <Container className="mt-4 mb-5">
+          <h2>Media Recovery</h2>
+          <p className="text-muted">
+            Recover missing database entries from files in the media directory, on a best-effort basis. Import the
+            uploads first, then the separated mixes - a mix can only be assigned to a track that already exists. If a
+            mix&apos;s original upload is gone, create a placeholder track for it from the Uploads tab. Use the play
+            buttons to preview files (or individual stems) by ear, and click underlined fields to fix metadata before
+            importing. Everything can still be edited later on the main page.
+          </p>
+          {scanErrors.length > 0 && (
+            <Alert variant="danger">
+              {scanErrors.map((error, index) => (
+                <div key={index}>{error}</div>
+              ))}
+            </Alert>
+          )}
+          {!isLoaded ? (
+            <Spinner animation="border" role="status" />
+          ) : (
+            <div>
+              {this.renderResults()}
+              <Tabs id="recovery-tabs" activeKey={this.state.activeTab} onSelect={this.onTabSelect} className="mt-4">
+                <Tab eventKey="uploads" title={`Uploads (${uploads.length})`}>
+                  {uploads.length === 0 ? (
+                    <p className="mt-3">No recoverable uploads found.</p>
+                  ) : (
+                    <div className="mt-3">
+                      <BootstrapTable
+                        bootstrap4
+                        keyField="id"
+                        data={uploads}
+                        columns={uploadColumns}
+                        selectRow={uploadSelectRow}
+                        cellEdit={cellEditFactory({ mode: 'click', blurToSave: true, autoSelectText: true })}
+                        bordered={false}
+                      />
+                      <Button
+                        variant="primary"
+                        disabled={importing || selectedUploadIds.length === 0}
+                        onClick={this.handleImportUploads}>
+                        {importing ? 'Importing...' : `Import ${selectedUploadIds.length} selected uploads`}
+                      </Button>
+                    </div>
+                  )}
+                  <hr />
+                  <h5>Create placeholder track</h5>
+                  <p className="text-muted">
+                    For mixes whose original upload is gone. Mixes with a matching name are assigned to it
+                    automatically.
+                  </p>
+                  <Form inline>
+                    <Form.Control
+                      className="mr-2 mb-2"
+                      placeholder="Artist"
+                      value={this.state.placeholderArtist}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                        this.setState({ placeholderArtist: event.target.value })
+                      }
+                    />
+                    <Form.Control
+                      className="mr-2 mb-2"
+                      placeholder="Title"
+                      value={this.state.placeholderTitle}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                        this.setState({ placeholderTitle: event.target.value })
+                      }
+                    />
+                    <Button
+                      variant="secondary"
+                      className="mb-2"
+                      disabled={importing || !this.state.placeholderTitle.trim()}
+                      onClick={this.handleCreatePlaceholder}>
+                      Create
+                    </Button>
+                  </Form>
+                </Tab>
+                <Tab eventKey="mixes" title={`Separated mixes (${mixes.length})`}>
+                  {mixes.length === 0 ? (
+                    <p className="mt-3">No recoverable mixes found.</p>
+                  ) : (
+                    <div className="mt-3">
+                      <BootstrapTable
+                        bootstrap4
+                        keyField="id"
+                        data={mixes}
+                        columns={mixColumns}
+                        selectRow={mixSelectRow}
+                        bordered={false}
+                      />
+                      <Button
+                        variant="primary"
+                        disabled={importing || numImportableMixes === 0}
+                        onClick={this.handleImportMixes}>
+                        {importing ? 'Importing...' : `Import ${numImportableMixes} selected mixes`}
+                      </Button>
+                      {numImportableMixes < selectedMixIds.length && (
+                        <span className="text-muted ml-3">
+                          {selectedMixIds.length - numImportableMixes} selected without a source track will be skipped
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </Tab>
+              </Tabs>
+            </div>
+          )}
+        </Container>
+      </div>
+    );
+  }
+}
+
+export default Recovery;

--- a/frontend/src/components/Recovery/Recovery.tsx
+++ b/frontend/src/components/Recovery/Recovery.tsx
@@ -258,17 +258,40 @@ class Recovery extends React.Component<Record<string, never>, State> {
     this.setState({ selectedMixIds: isSelected ? rows.map(row => row.id) : [] });
   };
 
-  trackChoiceOptions = (): Array<{ value: string; label: string }> => {
+  trackChoiceOptions = (): Array<{ value: string; label: string; title: string }> => {
     const { existingTracks } = this.state;
+    const trackName = (track: RecoveryTrackRef) => `${track.artist ? `${track.artist} - ` : ''}${track.title}`;
+    const countBy = (values: string[]) => {
+      const counts: { [value: string]: number } = {};
+      values.forEach(value => (counts[value] = (counts[value] ?? 0) + 1));
+      return counts;
+    };
+
+    // Tracks that share a name are indistinguishable by name alone, so those
+    // spell out the file they came from. The same file can also be uploaded
+    // twice, so anything still ambiguous falls back to part of the track ID.
+    const nameCounts = countBy(existingTracks.map(trackName));
+    const labelled = existingTracks.map(track => {
+      const name = trackName(track);
+      const file = track.path.split('/').pop() || 'no file';
+      return {
+        value: `track:${track.id}`,
+        label: nameCounts[name] > 1 ? `${name}  [${file}]` : name,
+        title: track.path || 'no file',
+      };
+    });
+    const labelCounts = countBy(labelled.map(option => option.label));
+
     return [
-      { value: '', label: 'Select a track...' },
+      { value: '', label: 'Select a track...', title: '' },
       // Sorted, because this list can run to hundreds of entries and is
       // otherwise in database insertion order
-      ...existingTracks
-        .map(track => ({
-          value: `track:${track.id}`,
-          label: `${track.artist ? `${track.artist} - ` : ''}${track.title}`,
-        }))
+      ...labelled
+        .map(option =>
+          labelCounts[option.label] > 1
+            ? { ...option, label: `${option.label}  #${option.value.slice(6, 14)}` }
+            : option
+        )
         .sort((a, b) => a.label.localeCompare(b.label)),
     ];
   };
@@ -450,7 +473,7 @@ class Recovery extends React.Component<Record<string, never>, State> {
               this.onTrackChoiceChange(row.id, event.target.value)
             }>
             {trackOptions.map(option => (
-              <option key={option.value} value={option.value}>
+              <option key={option.value} value={option.value} title={option.title}>
                 {option.label}
               </option>
             ))}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import Home from './components/Home/Home';
 import Mixer from './components/Mixer/Mixer';
 import NotFound from './components/NotFound';
+import Recovery from './components/Recovery/Recovery';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min';
 
@@ -13,6 +14,7 @@ const routing = (
       <Switch>
         <Route exact path="/" component={Home} />
         <Route path="/mixer/:mixId" component={Mixer} />
+        <Route path="/recovery" component={Recovery} />
         <Route component={NotFound} />
       </Switch>
     </div>

--- a/frontend/src/models/Recovery.ts
+++ b/frontend/src/models/Recovery.ts
@@ -1,0 +1,60 @@
+export interface RecoveryTrackMatch {
+  kind: 'track';
+  id: string;
+}
+
+export interface RecoveryUpload {
+  id: string;
+  filename: string;
+  url: string;
+  artist: string;
+  title: string;
+  date: string;
+}
+
+export interface RecoveryMix {
+  id: string;
+  type: 'static' | 'dynamic';
+  files: string[];
+  preview_url: string;
+  stem_urls: { [stem: string]: string };
+  prefix: string;
+  artist: string;
+  title: string;
+  parts: string[];
+  separator: string;
+  separator_args: Record<string, unknown>;
+  bitrate: number;
+  parsed: boolean;
+  normalized: boolean;
+  match: RecoveryTrackMatch | null;
+  date: string;
+  // Client-side only: the user's track association choice, encoded as
+  // 'track:<id>', or '' when no track is selected
+  track: string;
+}
+
+export interface RecoveryTrackRef {
+  id: string;
+  artist: string;
+  title: string;
+}
+
+export interface RecoveryScanResponse {
+  uploads: RecoveryUpload[];
+  mixes: Omit<RecoveryMix, 'track'>[];
+  existing_tracks: RecoveryTrackRef[];
+}
+
+export interface RecoveryImportResult {
+  id: string;
+  status: 'imported' | 'skipped' | 'error';
+  detail?: string;
+  track_id?: string;
+}
+
+export interface RecoveryImportResponse {
+  uploads: RecoveryImportResult[];
+  placeholders: RecoveryImportResult[];
+  mixes: RecoveryImportResult[];
+}

--- a/frontend/src/models/Recovery.ts
+++ b/frontend/src/models/Recovery.ts
@@ -38,6 +38,7 @@ export interface RecoveryTrackRef {
   id: string;
   artist: string;
   title: string;
+  path: string;
 }
 
 export interface RecoveryScanResponse {

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -4,5 +4,6 @@ from . import views
 
 urlpatterns = [
     path('', TemplateView.as_view(template_name='index.html')),
+    path('recovery/', TemplateView.as_view(template_name='index.html')),
     re_path('mixer/.*/', views.index, name='index')
 ]

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -18,6 +18,8 @@ server {
 
     location / {
         proxy_pass http://django_react;
+        # Must not be below the gunicorn timeout, or slow requests 504 here first
+        proxy_read_timeout 120s;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ validators==0.35.0
 whitenoise==6.11.0
 yapf==0.43.0
 youtube-title-parse==1.0.0
-yt-dlp @ git+https://github.com/JeffreyCA/yt-dlp@c22cf97c87f88662fdc5c3abc1d508b071e98c15
+yt-dlp @ git+https://github.com/JeffreyCA/yt-dlp@177c52ed430a2d7a2ce56f1962620d47ec54d1fd
 yt-dlp-ejs==0.8.0
 python-magic==0.4.27; sys_platform == 'linux'
 python-magic-bin==0.4.14; sys_platform != 'linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ validators==0.35.0
 whitenoise==6.11.0
 yapf==0.43.0
 youtube-title-parse==1.0.0
-yt-dlp @ git+https://github.com/JeffreyCA/yt-dlp@c1f39eda43ccdbe7065d38b2b43f5009f460199e
+yt-dlp @ git+https://github.com/JeffreyCA/yt-dlp@c22cf97c87f88662fdc5c3abc1d508b071e98c15
+yt-dlp-ejs==0.8.0
 python-magic==0.4.27; sys_platform == 'linux'
 python-magic-bin==0.4.14; sys_platform != 'linux'
 # Spleeter dependencies


### PR DESCRIPTION
Add a hidden /recovery page for rebuilding database entries from files remaining in the media directory, for recovering from database loss when the media files survived.

The scan endpoint parses upload and mix directories (whose names are the original UUID primary keys) and recovers metadata from audio tags and the metadata encoded in mix filenames. The page presents the results for review in two tabs: uploads are imported first with editable artist and title, then mixes are assigned to the recovered tracks, with placeholder tracks available for mixes whose original upload is gone. Files can be previewed by ear, including individual stems of dynamic mixes.

Recovery is best-effort and local storage only. Each item is imported in its own transaction and reported individually, and re-running skips anything already present.